### PR TITLE
Fix returned categories not being a list

### DIFF
--- a/app/api/stores/[storeId]/category/route.ts
+++ b/app/api/stores/[storeId]/category/route.ts
@@ -93,7 +93,7 @@ export async function GET(req: NextRequest, { params }: { params: { storeId: str
     });
 
     if (categories.length === 0) {
-      return NextResponse.json({ message: "No categories available for this store" });
+      return NextResponse.json([]);
     }
 
     return NextResponse.json(categories);


### PR DESCRIPTION
Fixes issue in dashboard where `categories` were not map:able.