### PR TITLE
Skip auth on GET requests to category and product

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,30 @@ import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware({
   publicRoutes: ["/api/:path*"],
-  ignoredRoutes: [
-    "/api/stores/:path*/category",
-    "/api/stores/:path*/product",
-    "/api/stores/:path*/product/:path*",
-  ],
+  ignoredRoutes(req) {
+    const isMethodGET = req.method === "GET";
+    const path = req.nextUrl.pathname;
+
+    //Allow GET requests to /api/stores/:path*/category
+    if (
+      isMethodGET &&
+      path.startsWith("/api/stores/") &&
+      path.endsWith("/category")
+    ) {
+      return true;
+    }
+
+    //Allow GET requests to /api/stores/:path*/product and /api/stores/:path*/product/:path*
+    if (
+      isMethodGET &&
+      path.startsWith("/api/stores/") &&
+      path.includes("/category")
+    ) {
+      return true;
+    }
+
+    return false;
+  },
 });
 
 export const config = {


### PR DESCRIPTION
Solves category creation handler resolving in 500 as `auth` was not available.

Ignores auth on GET requests to `category` and `product`.